### PR TITLE
chore: Fix path for generated JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "webpack",
+    "build": "webpack --mode production",
     "lint": "eslint .",
     "lint:ci": "eslint . --quiet",
     "start": "webpack serve --mode development",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   output: {
     filename: "main.js",
     path: path.resolve(__dirname, "build"),
-    publicPath: "/",
+    publicPath: "./",
   },
   module: {
     rules: [


### PR DESCRIPTION
The site was deployed to GitHub Pages, but the JS failed to load since it was requesting `/main.js` when the site is hosted under a nested path.