### PR TITLE
chore: Fix path routing for SPA for GitHub Pages (again)

### DIFF
--- a/src/client/router.ts
+++ b/src/client/router.ts
@@ -15,17 +15,18 @@ const indexRoute = new Route({
   component: App,
 });
 
+const routeTree = rootRoute.addChildren([indexRoute]);
+
 const notFoundRoute = new NotFoundRoute({
   getParentRoute: () => rootRoute,
   component: App,
 });
 
-const routeTree = rootRoute.addChildren([indexRoute, notFoundRoute]);
-
 const history = createBrowserHistory();
 
 const router = new Router({
   history,
+  notFoundRoute,
   routeTree,
 });
 


### PR DESCRIPTION
According to the [docs](https://tanstack.com/router/v1/docs/guide/route-matching#notfoundroutes-and-matching), the `NotFoundRoute` should be passed as an option instead of a child of the route tree.