### PR TITLE
chore: Add pulse animation to reload button

### DIFF
--- a/src/client/components/MainNavigation/index.tsx
+++ b/src/client/components/MainNavigation/index.tsx
@@ -88,7 +88,7 @@ const MainNavigation = ({ className }: Props) => {
                   }}
                   title="Reload to get newest version"
                 >
-                  <SyncProblemIcon sx={{ display: "block", fontSize: 16 }} />
+                  <SyncProblemIcon sx={{ display: "block", fontSize: 20 }} />
                 </ReloadButton>
               ) : null}
             </VersionInfo>

--- a/src/client/components/MainNavigation/styled.ts
+++ b/src/client/components/MainNavigation/styled.ts
@@ -1,4 +1,4 @@
-import styled from "styled-components";
+import styled, { keyframes } from "styled-components";
 import Button from "~/client/components/Button";
 import Logo from "~/client/components/Logo";
 import Separator from "~/client/components/Separator";
@@ -79,11 +79,26 @@ export const VersionInfoLink = styled(NavLink)`
   line-height: 16px;
 `;
 
+const pulse = keyframes`
+  from {
+    color: #818188;
+  }
+
+  10% {
+    color: #4100b3;
+  }
+
+  20%, to {
+    color: #818188;
+  }
+`;
+
 export const ReloadButton = styled(Button)`
   flex: 0;
   color: #818188;
-  padding: 8px;
+  padding: 6px;
   background: transparent;
+  animation: ${pulse} 5s linear infinite;
 
   &:hover {
     background-color: #dcdcde;

--- a/src/client/components/MainNavigation/styled.ts
+++ b/src/client/components/MainNavigation/styled.ts
@@ -80,7 +80,7 @@ export const VersionInfoLink = styled(NavLink)`
 `;
 
 const pulse = keyframes`
-  from {
+  0% {
     color: #818188;
   }
 
@@ -88,7 +88,7 @@ const pulse = keyframes`
     color: #4100b3;
   }
 
-  20%, to {
+  20%, 100% {
     color: #818188;
   }
 `;


### PR DESCRIPTION
Adds a pulsing animation that changes the color of the reload button icon in order to draw attention to it when there is a new version