### PR TITLE
ci: Fix duplicate deployments

### DIFF
--- a/.github/workflows/deploy-to-pages.yml
+++ b/.github/workflows/deploy-to-pages.yml
@@ -35,8 +35,6 @@ jobs:
 
   build:
     needs: ready
-    environment:
-      name: github-pages
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -44,7 +42,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: lts/*
           cache: npm
       - name: Setup Pages
         uses: actions/configure-pages@v5


### PR DESCRIPTION
It looked like deployments were getting duplicated, with one being created during the `build` job and one during the `deploy` job. I compared this workflow to a similar one in another repo that did not suffer from this same issue, and the only difference seemed to be an extra `environment` key present in this `build` job. This PR removes that and hopefully resolves the issue.

I also updated the pinned node version to point to the LTS alias.