### PR TITLE
ci: Fix environment variables in build and deploy jobs

### DIFF
--- a/.github/workflows/deploy-to-pages.yml
+++ b/.github/workflows/deploy-to-pages.yml
@@ -33,8 +33,11 @@ jobs:
           echo "Required workflow was not successful"
           exit 1
 
-  build:
+  build-and-deploy:
     needs: ready
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,14 +65,6 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./build
-
-  deploy:
-    needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Followup to https://github.com/anthony-j-castro/tiny-recipe-box/pull/186. It turns out that removing the `environment` key also prevented me from accessing environment variables (duh). For now,  I have to merge the two jobs in order to prevent the duplicate deployments until something like the feature requested in https://github.com/orgs/community/discussions/36919 is implemented.