### PR TITLE
chore: Fix new version check

### DIFF
--- a/src/client/hooks/useNewSiteVersionAvailable.ts
+++ b/src/client/hooks/useNewSiteVersionAvailable.ts
@@ -38,19 +38,19 @@ const useNewSiteVersionAvailable = () =>
   useQuery({
     queryKey: ["newSiteVersionAvailable"],
     queryFn: async () => {
-      const response = await fetch(
-        `https://api.github.com/repos/anthony-j-castro/tiny-recipe-box/deployments?${new URLSearchParams(
-          {
-            environment: "github-pages",
-            per_page: "1",
-          },
-        )}`,
-      );
-
-      const responseJson = await response.json();
+      const deploymentsResponse = await (
+        await fetch(
+          `https://api.github.com/repos/anthony-j-castro/tiny-recipe-box/deployments?${new URLSearchParams(
+            {
+              environment: "github-pages",
+              per_page: "1",
+            },
+          )}`,
+        )
+      ).json();
 
       const [lastDeployment] =
-        deploymentsApiResponseDecoder.verify(responseJson);
+        deploymentsApiResponseDecoder.verify(deploymentsResponse);
 
       if (lastDeployment.sha === config.GITHUB_COMMIT_SHA) {
         return false;

--- a/src/client/hooks/useNewSiteVersionAvailable.ts
+++ b/src/client/hooks/useNewSiteVersionAvailable.ts
@@ -49,16 +49,16 @@ const useNewSiteVersionAvailable = () =>
         )
       ).json();
 
-      const [lastDeployment] =
+      const [latestDeployment] =
         deploymentsApiResponseDecoder.verify(deploymentsResponse);
 
-      if (lastDeployment.sha === config.GITHUB_COMMIT_SHA) {
+      if (latestDeployment.sha === config.GITHUB_COMMIT_SHA) {
         return false;
       }
 
       const deploymentStatusResponse = await (
         await fetch(
-          `https://api.github.com/repos/anthony-j-castro/tiny-recipe-box/deployments/${lastDeployment.id}/statuses?${new URLSearchParams(
+          `https://api.github.com/repos/anthony-j-castro/tiny-recipe-box/deployments/${latestDeployment.id}/statuses?${new URLSearchParams(
             {
               per_page: "1",
             },


### PR DESCRIPTION
I was noticing the reload button was appearing before the deployment was fully live. This was happening because I was only checking if the latest employment existed and had a different SHA. This PR adds an additional request to get the status of most recent deployment and only indicates a new version is available if the `state` equals `success`.